### PR TITLE
Enables widescreen mode!

### DIFF
--- a/Content.Client/Chat/UI/ChatBox.xaml
+++ b/Content.Client/Chat/UI/ChatBox.xaml
@@ -5,7 +5,7 @@
          MinSize="200 128">
     <PanelContainer>
         <PanelContainer.PanelOverride>
-            <gfx:StyleBoxFlat BackgroundColor="#25252AAA" />
+            <gfx:StyleBoxFlat BackgroundColor="#25252ABB" />
         </PanelContainer.PanelOverride>
 
         <BoxContainer Orientation="Vertical">

--- a/Content.Client/Viewport/GameScreen.cs
+++ b/Content.Client/Viewport/GameScreen.cs
@@ -24,7 +24,7 @@ namespace Content.Client.Viewport
 {
     public sealed class GameScreen : GameScreenBase, IMainViewportState
     {
-        public static readonly Vector2i ViewportSize = (EyeManager.PixelsPerMeter * 21, EyeManager.PixelsPerMeter * 15);
+        public static readonly Vector2i ViewportSize = (EyeManager.PixelsPerMeter * 27, EyeManager.PixelsPerMeter * 15);
 
         [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
         [Dependency] private readonly IGameHud _gameHud = default!;


### PR DESCRIPTION
Makes the visible playfield is 16:9 instead of 4:3, and also adjusts the chatbox for better contrast.

I don't think you have the changelog bot set up so this won't do anything but:

## Changelog
:cl: moony
- tweak: The game is now in widescreen mode.